### PR TITLE
Issue 38: add complete reporting triangle as a model permutation

### DIFF
--- a/_targets.R
+++ b/_targets.R
@@ -101,7 +101,8 @@ mapped_covid <- tar_map(
     age_group_to_nowcast = config$covid$age_groups,
     n_history_delay = config$covid$n_history_delay,
     n_history_uncertainty = config$covid$n_history_uncertainty,
-    borrow = config$covid$borrow
+    borrow = config$covid$borrow,
+    partial_rep_tri = config$covid$partial_rep_tri
   ),
   # 1. Generate nowcasts and aggregate (baselinenowcast pipeline)
   # 2. Save quantiled nowcasts for visualisation

--- a/input/config/config.yaml
+++ b/input/config/config.yaml
@@ -78,7 +78,23 @@ covid:
   - '2022-02-01'
   - '2022-04-01'
   - '2022-04-20'
+  - '2021-12-01'
+  - '2022-02-01'
+  - '2022-04-01'
+  - '2022-04-20'
+  - '2021-12-01'
+  - '2022-02-01'
+  - '2022-04-01'
+  - '2022-04-20'
   age_groups:
+  - 00+
+  - 00+
+  - 00+
+  - 00+
+  - 60-79
+  - 60-79
+  - 60-79
+  - 60-79
   - 00+
   - 00+
   - 00+
@@ -176,6 +192,14 @@ covid:
   - 60.0
   - 60.0
   - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
   n_history_uncertainty:
   - 60.0
   - 60.0
@@ -217,6 +241,14 @@ covid:
   - 10.0
   - 10.0
   - 10.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
   - 60.0
   - 60.0
   - 60.0
@@ -274,6 +306,14 @@ covid:
   - 60.0
   - 60.0
   - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
+  - 60.0
   borrow:
   - no
   - no
@@ -323,6 +363,71 @@ covid:
   - yes
   - yes
   - yes
+  - no
+  - no
+  - no
+  - no
+  - no
+  - no
+  - no
+  - no
+  partial_rep_tri:
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - yes
+  - no
+  - no
+  - no
+  - no
+  - no
+  - no
+  - no
+  - no
   max_delay: 40.0
   days_to_eval: 29.0
   quantiles:

--- a/src/write_config.R
+++ b/src/write_config.R
@@ -5,8 +5,7 @@ write_config <- function(noro_nowcast_dates = NULL,
                          age_groups_covid = NULL,
                          n_history_uncertainty_covid = NULL,
                          n_history_delay_covid = NULL,
-                         borrow_delay = NULL,
-                         borrow_uncertainty = NULL) {
+                         borrow = NULL) {
   norovirus_url <- "https://raw.githubusercontent.com/jonathonmellor/norovirus-nowcast/refs/heads/main/outputs/data/cases_with_noise.csv" # nolint
   # covid_url <- "https://raw.githubusercontent.com/KITmetricslab/hospitalization-nowcast-hub/main/data-truth/COVID-19/COVID-19_hospitalizations_preprocessed.csv" # nolint
   # Use the august 8th data, as is in the paper
@@ -75,6 +74,7 @@ write_config <- function(noro_nowcast_dates = NULL,
   max_delay <- 40
   base_n_history <- 3 * max_delay
   base_borrow <- FALSE
+  partial_rep_tri <- TRUE
   if (is.null(age_groups_covid)) {
     age_groups_covid <- c("00+", "00-04", "05-14", "15-34", "35-59", "60-79", "80+")
   }
@@ -87,7 +87,8 @@ write_config <- function(noro_nowcast_dates = NULL,
       n_history = base_n_history,
       n_history_delay = round(0.5 * base_n_history),
       n_history_uncertainty = round(0.5 * base_n_history),
-      borrow = base_borrow
+      borrow = base_borrow,
+      partial_rep_tri = partial_rep_tri
     )
   # result_df should be 7* length of df_base_covid
   result_df <- create_pairwise_variations(df_base_covid,
@@ -118,6 +119,7 @@ write_config <- function(noro_nowcast_dates = NULL,
       n_history_uncertainty = result_df |> pull(n_history_uncertainty) |> as.vector(),
       n_history_dispersion = result_df |> pull(n_history_uncertainty) |> as.vector(),
       borrow = result_df |> pull(borrow) |> as.vector(),
+      partial_rep_tri = result_df |> pull(partial_rep_tri) |> as.vector(),
       max_delay = 40,
       days_to_eval = 29, # 0 to - 28 horizon)
       quantiles = c(0.025, 0.1, 0.25, 0.5, 0.75, 0.9, 0.975),
@@ -139,7 +141,7 @@ create_pairwise_variations <- function(df_base_covid,
                                        max_delay = max_delay) {
   # Original parameters
   params <- c("n_history_delay", "n_history_uncertainty")
-  params_bool <- "borrow"
+  params_bool <- c("borrow", "partial_rep_tri")
 
   # Loop through each numeric parameter
   for (i in seq_along(params)) {

--- a/targets/gen_covid_nowcast_targets.R
+++ b/targets/gen_covid_nowcast_targets.R
@@ -40,6 +40,18 @@ gen_covid_nowcast_targets <- list(
             -reference_date, -nowcast_date
           ) |>
           as.matrix()
+      } else if (!partial_rep_tri) {
+        get_rep_tri_from_long_df(
+          long_df = covid_long,
+          nowcast_date = nowcast_dates_covid,
+          max_delay = config$covid$max_delay
+        ) |>
+          # Remove all the reference dates with incomplete data
+          filter(reference_date <= ymd(nowcast_dates_covid) - days(config$covid$max_delay)) |>
+          select(
+            -reference_date, -nowcast_date
+          ) |>
+          as.matrix()
       } else {
         triangle
       }

--- a/targets/gen_covid_nowcast_targets.R
+++ b/targets/gen_covid_nowcast_targets.R
@@ -90,6 +90,18 @@ gen_covid_nowcast_targets <- list(
             -reference_date, -nowcast_date
           ) |>
           as.matrix()
+      } else if (!partial_rep_tri) {
+        get_rep_tri_from_long_df(
+          long_df = covid_long,
+          nowcast_date = nowcast_dates_covid,
+          max_delay = config$covid$max_delay
+        ) |>
+          # Remove all the reference dates with incomplete data
+          filter(reference_date <= ymd(nowcast_dates_covid) - days(config$covid$max_delay)) |>
+          select(
+            -reference_date, -nowcast_date
+          ) |>
+          as.matrix()
       } else {
         triangle
       }


### PR DESCRIPTION
## Description

This PR closes #38. It adds another permutation dimensions `partial_rep_tri` which uses the completely observed portion of the reporting triangle to estimate delays and uncertainty.  Just forgot in last PR.

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
