### PR TITLE
Issue 49: Rerun KIT simple nowcasts and compare to this

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,8 @@ Suggests:
     usethis,
     roxyglobals,
     withr,
-    knitr
+    knitr,
+    yaml
 Encoding: UTF-8
 Language: en-GB
 Roxygen: list(markdown = TRUE, roclets = c("collate", "namespace", "rd",

--- a/R/figures_eda.R
+++ b/R/figures_eda.R
@@ -55,6 +55,8 @@ get_plot_data_as_of <- function(final_df,
 #'   wish to plot, default is `NULL` which will plot all of them
 #' @param pathogen Character sting of the pathogen being plotted
 #' @param title Character string indicating the title
+#' @param facet Boolean indicating whether or not to make separate facets
+#'    of each model
 #'
 #' @autoglobal
 #' @importFrom ggplot2 aes geom_line ggplot ggtitle xlab ylab theme_bw
@@ -68,7 +70,8 @@ get_plot_mult_nowcasts <- function(all_nowcasts,
                                    final_summed_data,
                                    nowcast_dates_to_plot = NULL,
                                    pathogen = "",
-                                   title = "") {
+                                   title = "",
+                                   facet = FALSE) {
   final_df <- final_summed_data |>
     filter(
       reference_date >= min(all_nowcasts$reference_date),
@@ -116,8 +119,8 @@ get_plot_mult_nowcasts <- function(all_nowcasts,
       ),
       color = "magenta4"
     ) +
-    geom_point(
-      aes(x = reference_date, y = observed),
+    geom_line(
+      aes(x = reference_date, y = observed, group = nowcast_date),
       color = "darkblue"
     ) +
     geom_line(
@@ -150,6 +153,11 @@ get_plot_mult_nowcasts <- function(all_nowcasts,
     coord_cartesian(ylim = c(0, 1.01 * max(all_nowcasts$`q_0.975`))) + # nolint
     ggtitle(glue("{title}"))
 
+  if (isTRUE(facet)) {
+    p <- p + facet_wrap(~model, nrow = 3)
+  }
+
+
   return(p)
 }
 
@@ -164,6 +172,8 @@ get_plot_mult_nowcasts <- function(all_nowcasts,
 #'   wish to plot, default is `NULL` which will plot all of them
 #' @param pathogen Character sting of the pathogen being plotted
 #' @param title Character string indicating the title
+#' @param facet Boolean indicating whether or not to make separate facets
+#'    of each model
 #'
 #' @autoglobal
 #' @importFrom ggplot2 aes geom_line ggplot ggtitle xlab ylab theme_bw
@@ -177,7 +187,8 @@ get_plot_pt_nowcasts <- function(pt_nowcasts_combined,
                                  final_summed_data,
                                  nowcast_dates_to_plot = NULL,
                                  pathogen = "",
-                                 title = "") {
+                                 title = "",
+                                 facet = FALSE) {
   final_df <- final_summed_data |>
     filter(
       reference_date >= min(pt_nowcasts_combined$reference_date),
@@ -238,6 +249,11 @@ get_plot_pt_nowcasts <- function(pt_nowcasts_combined,
       na.rm = TRUE
     ))) +
     ggtitle(glue("{title}"))
+
+  if (isTRUE(facet)) {
+    p <- p + facet_wrap(~model, nrow = 3)
+  }
+
 
   return(p)
 }

--- a/R/figures_hub_validation.R
+++ b/R/figures_hub_validation.R
@@ -357,19 +357,31 @@ get_plot_bar_chart_coverage <- function(all_coverage,
 #'    geom_hline scale_y_continuous
 #' @importFrom dplyr mutate select
 #' @importFrom tidyr pivot_wider
+#' @importFrom glue glue
 #' @returns ggplot object
-get_plot_rel_wis_by_age_group <- function(scores_by_age_group) {
-  scores_wide <- scores_by_age_group |>
-    select(wis, model, age_group) |>
-    pivot_wider(
-      names_from = model,
-      values_from = wis
-    ) |>
-    mutate(relative_wis = baselinenowcast / `KIT simple nowcast`)
+get_plot_rel_wis_by_age_group <- function(scores_by_age_group,
+                                          KIT_comparison_model = "KIT simple nowcast") {
+  KIT_comparison <- scores_by_age_group |>
+    filter(model == KIT_comparison_model) |>
+    rename(comparison_wis = wis) |>
+    select(comparison_wis, age_group)
+
+  rel_wis <- scores_by_age_group |>
+    filter(model != KIT_comparison_model) |>
+    left_join(KIT_comparison, by = "age_group") |>
+    mutate(rel_wis = wis / comparison_wis)
+
   plot_comps <- plot_components()
-  p <- ggplot(scores_wide) +
-    geom_point(aes(x = age_group, y = relative_wis)) +
+  p <- ggplot(rel_wis) +
+    geom_point(aes(
+      x = age_group, y = rel_wis,
+      fill = model
+    )) +
     scale_fill_manual(
+      name = "",
+      values = plot_comps$model_colors
+    ) +
+    scale_color_manual(
       name = "",
       values = plot_comps$model_colors
     ) +
@@ -378,7 +390,7 @@ get_plot_rel_wis_by_age_group <- function(scores_by_age_group) {
     coord_flip() +
     get_plot_theme() +
     labs(x = "", y = "Relative WIS") +
-    ggtitle("Relative WIS by age group")
+    ggtitle(glue::glue("Relative WIS by age group relative to {KIT_comparison_model}")) # nolint
   return(p)
 }
 #' Get a plot of mean WIS by horizon
@@ -425,6 +437,7 @@ get_plot_mean_wis_by_horizon <- function(scores,
 #'
 #' @param scores Dataframe of all the scores by individual reference and
 #'    nowcast dates and model and age groups
+#' @param KIT_comparison_model Character string indicating which model to compare to
 #' @inheritParams get_plot_bar_chart_sum_scores
 #' @autoglobal
 #' @importFrom ggplot2 ggplot geom_line aes labs scale_color_manual
@@ -433,7 +446,8 @@ get_plot_mean_wis_by_horizon <- function(scores,
 #' @importFrom glue glue
 #' @returns ggplot object
 get_plot_rel_wis_by_horizon <- function(scores,
-                                        strata) {
+                                        strata,
+                                        KIT_comparison_model = "KIT simple nowcast") {
   if (strata == "age groups") {
     scores_filtered <- filter(
       scores, age_group != "00+"
@@ -447,20 +461,25 @@ get_plot_rel_wis_by_horizon <- function(scores,
   scores_sum <- scores_filtered |>
     mutate(horizon = as.integer(reference_date - nowcast_date)) |>
     scoringutils::summarise_scores(by = c("model", "horizon")) |>
-    select(model, horizon, wis) |>
-    pivot_wider(
-      names_from = model,
-      values_from = wis
-    ) |>
-    mutate(relative_wis = baselinenowcast / `KIT simple nowcast`)
+    select(model, horizon, wis)
 
-  p <- ggplot(scores_sum, aes(x = horizon, y = relative_wis)) +
-    geom_line() +
+  KIT_comparison <- scores_sum |>
+    filter(model == KIT_comparison_model) |>
+    rename(comparison_wis = wis) |>
+    select(comparison_wis, horizon)
+
+  relative_wis <- scores_sum |>
+    filter(model != KIT_comparison_model) |>
+    left_join(KIT_comparison, by = "horizon") |>
+    mutate(rel_wis = wis / comparison_wis)
+
+  p <- ggplot(relative_wis) +
+    geom_line(aes(x = horizon, y = rel_wis, color = model)) +
     get_plot_theme() +
     geom_hline(aes(yintercept = 1), linetype = "dashed") +
-    scale_y_continuous(trans = "log", limits = c(0.6, 2.5)) +
+    scale_y_continuous(trans = "log") +
     labs(x = "Horizon (days)", y = "Relative WIS") +
-    ggtitle(glue::glue("Relative WIS by horizon: {strata}"))
+    ggtitle(glue::glue("Relative WIS by horizon: {strata} relative to {KIT_comparison_model}"))
 
   return(p)
 }

--- a/R/globals.R
+++ b/R/globals.R
@@ -79,12 +79,10 @@ utils::globalVariables(c(
   "empirical_coverage", # <get_plot_bar_chart_coverage>
   "95", # <get_plot_bar_chart_coverage>
   "50", # <get_plot_bar_chart_coverage>
-  "wis", # <get_plot_rel_wis_by_age_group>
   "model", # <get_plot_rel_wis_by_age_group>
+  "wis", # <get_plot_rel_wis_by_age_group>
+  "comparison_wis", # <get_plot_rel_wis_by_age_group>
   "age_group", # <get_plot_rel_wis_by_age_group>
-  "baselinenowcast", # <get_plot_rel_wis_by_age_group>
-  "KIT simple nowcast", # <get_plot_rel_wis_by_age_group>
-  "relative_wis", # <get_plot_rel_wis_by_age_group>
   "age_group", # <get_plot_mean_wis_by_horizon>
   "reference_date", # <get_plot_mean_wis_by_horizon>
   "nowcast_date", # <get_plot_mean_wis_by_horizon>
@@ -97,9 +95,8 @@ utils::globalVariables(c(
   "model", # <get_plot_rel_wis_by_horizon>
   "horizon", # <get_plot_rel_wis_by_horizon>
   "wis", # <get_plot_rel_wis_by_horizon>
-  "baselinenowcast", # <get_plot_rel_wis_by_horizon>
-  "KIT simple nowcast", # <get_plot_rel_wis_by_horizon>
-  "relative_wis", # <get_plot_rel_wis_by_horizon>
+  "comparison_wis", # <get_plot_rel_wis_by_horizon>
+  "rel_wis", # <get_plot_rel_wis_by_horizon>
   "age_group", # <get_plot_coverage_by_horizon>
   "interval_range", # <get_plot_coverage_by_horizon>
   "reference_date", # <get_plot_coverage_by_horizon>

--- a/R/plotting_style.R
+++ b/R/plotting_style.R
@@ -25,6 +25,7 @@ plot_components <- function() {
   # nolint start
   model_colors <- c(
     "KIT simple nowcast" = "darkgreen",
+    "KIT simple nowcast revised" = "darkorange",
     "baselinenowcast" = "purple4"
   )
   age_colors <- c(

--- a/man/get_plot_mult_nowcasts.Rd
+++ b/man/get_plot_mult_nowcasts.Rd
@@ -9,7 +9,8 @@ get_plot_mult_nowcasts(
   final_summed_data,
   nowcast_dates_to_plot = NULL,
   pathogen = "",
-  title = ""
+  title = "",
+  facet = FALSE
 )
 }
 \arguments{
@@ -24,6 +25,9 @@ wish to plot, default is \code{NULL} which will plot all of them}
 \item{pathogen}{Character sting of the pathogen being plotted}
 
 \item{title}{Character string indicating the title}
+
+\item{facet}{Boolean indicating whether or not to make separate facets
+of each model}
 }
 \value{
 ggplot object

--- a/man/get_plot_pt_nowcasts.Rd
+++ b/man/get_plot_pt_nowcasts.Rd
@@ -9,7 +9,8 @@ get_plot_pt_nowcasts(
   final_summed_data,
   nowcast_dates_to_plot = NULL,
   pathogen = "",
-  title = ""
+  title = "",
+  facet = FALSE
 )
 }
 \arguments{
@@ -25,6 +26,9 @@ wish to plot, default is \code{NULL} which will plot all of them}
 \item{pathogen}{Character sting of the pathogen being plotted}
 
 \item{title}{Character string indicating the title}
+
+\item{facet}{Boolean indicating whether or not to make separate facets
+of each model}
 }
 \value{
 ggplot object

--- a/man/get_plot_rel_wis_by_age_group.Rd
+++ b/man/get_plot_rel_wis_by_age_group.Rd
@@ -4,7 +4,10 @@
 \alias{get_plot_rel_wis_by_age_group}
 \title{Get a plot of relative WIS by age group}
 \usage{
-get_plot_rel_wis_by_age_group(scores_by_age_group)
+get_plot_rel_wis_by_age_group(
+  scores_by_age_group,
+  KIT_comparison_model = "KIT simple nowcast"
+)
 }
 \arguments{
 \item{scores_by_age_group}{Dataframe of the summarised scores by age group

--- a/man/get_plot_rel_wis_by_horizon.Rd
+++ b/man/get_plot_rel_wis_by_horizon.Rd
@@ -4,7 +4,11 @@
 \alias{get_plot_rel_wis_by_horizon}
 \title{Get a plot of relative WIS by horizon}
 \usage{
-get_plot_rel_wis_by_horizon(scores, strata)
+get_plot_rel_wis_by_horizon(
+  scores,
+  strata,
+  KIT_comparison_model = "KIT simple nowcast"
+)
 }
 \arguments{
 \item{scores}{Dataframe of all the scores by individual reference and
@@ -13,6 +17,8 @@ nowcast dates and model and age groups}
 \item{strata}{Character string indicating whether to summarise across the
 different age strata (\code{"age groups"}) or across the nation as a whole
 (\code{"national"}). Default is \code{"age groups"}.}
+
+\item{KIT_comparison_model}{Character string indicating which model to compare to}
 }
 \value{
 ggplot object

--- a/src/write_config.R
+++ b/src/write_config.R
@@ -12,6 +12,7 @@ write_config <- function(noro_nowcast_dates = NULL,
   # Use the august 8th data, as is in the paper
   covid_url <- "https://raw.githubusercontent.com/KITmetricslab/hospitalization-nowcast-hub/11c745322c055cfbd4f0c8f72241642a50aea399/data-truth/COVID-19/COVID-19_hospitalizations_preprocessed.csv"
   KIT_nowcast_url_prefix <- "https://raw.githubusercontent.com/KITmetricslab/hospitalization-nowcast-hub/refs/heads/main/data-processed/KIT-simple_nowcast"
+  KIT_nowcast_revised_url_prefix <- "https://raw.githubusercontent.com/kaitejohnson/hospitalization-nowcast-hub/refs/heads/main/data-processed_retrospective/KIT-simple_nowcast_revised" # point to the bug fixed quantiles
   if (is.null(noro_nowcast_dates)) {
     noro_nowcast_dates <- as.character(
       seq(
@@ -119,6 +120,7 @@ write_config <- function(noro_nowcast_dates = NULL,
     covid = list(
       url = covid_url,
       KIT_nowcast_url_prefix = KIT_nowcast_url_prefix,
+      KIT_nowcast_revised_url_prefix = KIT_nowcast_revised_url_prefix,
       nowcast_dates = result_df |> pull(nowcast_dates) |> as.vector(),
       age_groups = result_df |> pull(age_groups) |> as.vector(),
       n_history_delay = result_df |> pull(n_history_delay) |> as.vector(),

--- a/targets/EDA_plot_targets.R
+++ b/targets/EDA_plot_targets.R
@@ -84,7 +84,8 @@ EDA_plot_targets <- list(
       final_summed_data = final_eval_data_covid_7d,
       nowcast_dates_to_plot = c("2021-12-01", "2022-02-01", "2022-04-01"),
       pathogen = "Covid 7 day",
-      title = "KIT vs baselinenowcast nowcasts"
+      title = "KIT vs baselinenowcast nowcasts",
+      facet = FALSE
     )
   ),
   tar_target(
@@ -109,7 +110,8 @@ EDA_plot_targets <- list(
       final_summed_data = final_eval_data_covid_7d,
       nowcast_dates_to_plot = c("2021-12-01", "2022-02-01", "2022-04-01"),
       pathogen = "Covid 7 day",
-      title = "Point nowcast comparison"
+      title = "Point nowcast comparison",
+      facet = FALSE
     )
   ),
   tar_target(

--- a/targets/figures_hub_validation_targets.R
+++ b/targets/figures_hub_validation_targets.R
@@ -91,6 +91,13 @@ figures_hub_validation_targets <- list(
     )
   ),
   tar_target(
+    name = plot_rel_wis_by_horizon_ag_revised,
+    command = get_plot_rel_wis_by_horizon(validation_scores,
+      strata = "age groups",
+      KIT_comparison_model = "KIT simple nowcast revised"
+    )
+  ),
+  tar_target(
     name = horiz_bar_chart_coverage_ntl,
     command = get_plot_bar_chart_coverage(validation_coverage,
       strata = "national"


### PR DESCRIPTION
## Description

This PR closes #49. Using the quantiles produced in https://github.com/kaitejohnson/hospitalization-nowcast-hub/pull/3, we are now additionally loading in the retrospectively generated nowcasts using the KIT simple nowcast method code from the hospitalization nowcast Hub repository, with the last column for the density beyond the max delay removed. 

To see more about how the code was changed to generate these refer to that PR. 

In this PR, we additionally load these in and add them to all the subplots of the Hub validation plots. I will post these here when they have finished running. 

For the plots of relative scores, we make both versions (one compared to the real-time submissions and one compared to the revised retrospective submissions). 

Here's an example from the 3 dates, (pretty hard to distinguish between KIT simple nowcast revised and baselinenowcast because they are overlapping)
![image](https://github.com/user-attachments/assets/201f87ee-5def-46fb-9051-ca2f50eb8e6e)


## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
