### PR TITLE
Issue 60: ensure math in supp aligns with current package

### DIFF
--- a/docs/supplement.qmd
+++ b/docs/supplement.qmd
@@ -41,13 +41,13 @@ is the number of cases still missing after $d$ delay. We refer to $X_t$ to descr
 
 #### Estimate of the delay distribution from a reporting matrix
 
-We can use a reporting matrix to compute an empirical estimate of the delay distribution, $\pi(d)$. The empirical delay distribution, $\pi(d)$ can be computed directly from the reporting matrix $X$
+We can use a reporting matrix to compute an empirical estimate of the delay distribution, $\pi(d)$. The empirical delay distribution, $\pi(d)$ can be computed directly from the reporting matrix $X$ using the latest $N$ reference times via:
 
 $$
-\pi(d)= \frac{\sum_{t=1}^{t=t^*} X_{t,d}}{\sum_{d=0}^{D} \sum_{t=1}^{t=t^*} X_{t,d}}
+\pi(d)= \frac{\sum_{t=t^*-N}^{t=t^*} X_{t,d}}{\sum_{d'=0}^{D} \sum_{t=t^*-N}^{t=t^*} X_{t,d'}}
 $$
 
-Where the numerator is the sum of all the observations across reference times $t$ for a particular delay $d$, and the denominator is the sum across all reference times $t$ and delays $d$.
+Where the numerator is the sum of all the observations across reference times $t$ for a particular delay $d$ of interest, and the denominator is the sum across all reference times $t$ and indexed delays in the reporting matrix $d'$.
 
 #### Estimate of the delay distribution from a reporting triangle
 
@@ -57,7 +57,9 @@ The multiplicative model works by iteratively "filling in" the reporting triangl
 
 ![Visual description of the iterative “completing” of the reporting triangle, moving from left to right and bottom to top. In this cases, we are imputing \$x\_{t=6, d = 2}\$ and \$x\_{t=5, d= 2}\$ assuming that the ratio between \$x\_{t=1:4, d = 2}\$ (block top), and \$x\_{t=1:4, d=0:1}\$ (block top left) holds for for \$x\_{t=5:6, d = 2}\$ (block bottom) and \$x\_{t=5:6, d = 0:1}\$ (block bottom left). In this example, \$\\hat{x}\_{t=6, d = 1}\$ has already been imputed using the same approach, and we treat it as known going forward. This process is repeated across the reporting triangle to estimate all values outlined in the dashed lines.](schematic_fig.png){#fig1}
 
-The method requires at least one observation, at delay $d=0$ for the most recent reference time, located at the bottom left of the reporting triangle in Figure \@ref(fig1) above. This means that in practice, the reporting triangle must have at least the same number of rows as it does columns. The method assumes that the values at each delay $d$ for the recent times, $t$, will consist of the same proportion of the values previously reported for earlier times $t$. To fill in the missing values for each column $d$, we sum over the rectangle of completely observed reference times for all $d-1$ columns (block top left) and sum over the column of completely observed reference times for all of the entries in column $d$ (block left). The ratio of these two sums is assumed to be the same in the missing entries in column $d$, so we use the entries observed up to $d-1$ for each incomplete reference time (block bottom left), and scale by this ratio to get the missing entries in column $d$. This process is repeated for each delay from $d$ up to the maximum delay $D$. At each iteration an additional reference time entry is computed as the delay $d$ increases.
+The method requires at least one observation, at delay $d=0$ for the most recent reference time, located at the bottom left of the reporting triangle in Figure \@ref(fig1) above.
+The method assumes that the values at each delay $d$ for the recent times, $t$, will consist of the same proportion of the values previously reported for earlier times $t$.
+To fill in the missing values for each column $d$, we sum over the rectangle of completely observed reference dates for all $d-1$ columns (block top left) and sum over the column of completely observed reference dates for all of the entries in column $d$ (block left). The ratio of these two sums is assumed to be the same in the missing entries in column $d$, so we use the entries observed up to $d-1$ for each incomplete reference date (block bottom left), and scale by this ratio to get the missing entries in column $d$. This process is repeated for each delay from $d$ up to the maximum delay $D$. At each iteration an additional reference time entry is computed as the delay $d$ increases.
 
 The delay distribution is then estimated from the filled in reporting matrix, using the same algorithm as described above for the case of the complete reporting matrix.
 
@@ -79,47 +81,56 @@ Where the number of reports at timepoint $t$ with delay $d$ is the product of th
 
 ### Uncertainty estimation
 
-To estimate the uncertainty in the nowcasts, we use past nowcast errors and assume a negative binomial observation model.
+To estimate the uncertainty in the nowcasts, we use past nowcast errors.
+In this analysis, we assume a negative binomial observation model.
 
 #### Generation of retrospective reporting triangles
 
 We describe a method which generates retrospective reporting triangles to replicate what would have been available as of time $t^*=s^*$, where $s^* = t^*-m$ for $m = 1, 2, ... M$ to generate $M$ retrospective reporting triangles.
 
-To generate the set of $M$ reporting triangles, we simply remove the last $m$ rows of the existing reporting triangle (or reporting matrix), to generate $M$ truncated incomplete reporting matrices. The method uses each retrospective reporting triangle to re-estimate a delay distribution using the $N$ preceding rows of the reporting triangle before $s^*$, and recomputes a retrospective nowcast, for $M$ realizations of the retrospective reporting triangle (so $M$ different $s^*$ values).
+To generate the set of $M$ reporting triangles, we work backwards from most recent to oldest, removing the last $m$ rows of the existing reporting triangle, to generate $M$ truncated reporting triangles.
+We then replace the bottom right of the triangle with NAs, assuming these would not have been observed as of $s^*$, to generare $M$ retrospective reporting triangles.
+
+The method uses each retrospective reporting triangle to re-estimate a delay distribution using the $N$ preceding reference times of the retrospective reporting triangle before $s^*$, and recomputes a retrospective point nowcast matrix, for $M$ realizations of the retrospective reporting triangle (so $M$ different $s^*$ values).
+
+Thus in order to estimate uncertainty using $N$ reference times, the total training volume must meet or exceed $N+M$ so that the oldest retrospective nowcast dataset at $s^* = t^*-M$ can use $N$ reference times for its point nowcast.
 
 #### Generation of retrospective point nowcast matrices
 
 From the $M$ reporting triangles, we apply the method described above to estimate a delay distribution from a reporting triangle and generate a point nowcast for each reporting triangle, to generate $M$ point nowcasts.
 
-#### Fit point nowcast matrices and observed values to a negative binomial observation model at each delay
+#### Fit predicted point nowcast vectors and obesrved counts to a negative binomial observation model at each forecast horizon
 
-We then take the list of point nowcast matrices, and the list of truncated incomplete reporting matrices (these do not necessarily contains NAs on the bottom right, the bottom right could be entirely or partially observed). For each delay $d$ we identify the overlapping set of matrix elements that were imputed retrospectively and matrix elements that had been observed as of the most recent time point.
+We quantify the uncertainty at the target quantity level, which is assumed, by default, to be the final count at each reference time, summed across reporting delays.
 
-For each delay $d = 1, ..., D$ we assume that the observed values, $X_{s^*-d, >d}$ follow a negative binomial observation model with a mean of $\hat{x}_{s^*-d}$:
+At each retrospective nowcast time $s^*$, we compute the predicted and corresponding observed nowcast at each forecast horizon $j = 1, ..., D$ by summing across the reporting delays for all delays $d$ that have been observed as of time $t^*$, as indicated below by the indicator function. We define the predicted nowcast for forecast horizon $j$ at retrospective nowcast time $s^*$
+$$
+\hat{X}_{t-j}(s^*) = \sum_{d=0}^{D} \hat{X}_{t-j,d}(s^*) \times I(t-j+d \leq t^*)
+$$
+and likewise the observed nowcast for forecast horizon $j$ at retrospective nowcast time $s^*$
+$$
+X_{t-j}(s^*) = \sum_{d=0}^{D} X_{t-j,d}(s^*) \times I(t-j+d \leq t^*)
+$$
+
+This generates $M$ pairs of predicted nowcasts and observed nowcasts for each forecast horizon $j = 1, ..., D$. We assume that the observed nowcasts $X_{t-j}$ follow a negative binomial observation model with a mean of $\hat{X}_{t-j}(t^*-j)$
 
 $$
-X_{s^*-d,>d} | \hat{x}_{s^*-d, >d}(s*) \sim NegBin(\mu = \hat{x}_{s^*-d} + 0.1, \phi = \phi_d)
-$$
+X_{t-j} | \hat{X}_{t-j}(t^* - j) \sim NegBin(\mu = \hat{X}_{t-j}(t^*-j) + 0.1, \phi = \phi_{t^*-t})
+$$ for all $s^* = 1, ..., M$.
 
-We add a small number (0.1) to the mean to avoid an ill-defined negative binomial. We note that to perform all these computations, data snapshots from at least $N + M$ past observations, or rows of the original reporting triangle (or matrix), are needed. This estimate of the uncertainty accounts for the empirical uncertainty in the point estimate of the delay distribution over time.
+We add a small number (0.1) to the mean to avoid an ill-defined negative binomial.
+This generates a vector of negative binomial dispersion parameters indexed starting at forecast horizon $j=1$.
+
 
 ### Probabilistic nowcast generation
 
-Using the dispersion parameters for each delay, $\phi(d),$ for $d = 1,...D$, we can generate probabilistic nowcast matrices by drawing samples from the negative binomial:
+Using the dispersion parameters for each forecast horizon, $\phi(j),$ for $j = 1,...D$, we can generate probabilistic nowcast matrices by drawing samples from the negative binomial:
 
 $$
-X_{t,d} \sim NegBin(\mu = \hat{x}_{t,d}, \phi = \phi(d))
+X_{t^*-j} \sim NegBin(\mu = \hat{X}_{t^*-j}, \phi = \phi(j))
 $$
 
-### Nowcast creation
-
-To generate nowcast vectors that represent the expected final number of cases at each reference time, we aggregate the reporting matrices $X_{t,d}$ which contain a mix of observed and imputed values. We refer to the sum across delays as $X_{t,>d}$, or $x_t$
-
-$$
-X_{t,>d} = x_t = \sum_{i = d+1} ^{D} X_{t,i}
-$$
-
-We can then used the probabilistic draws to compute any desired quantiles to summarize the outputs.
+We can sample for any number of draws, and then use the draws to compute any desired quantiles to summarize the outputs.
 
 ### Zero-handling approximation {#zero-handling-approximation}
 


### PR DESCRIPTION
## Description

This PR closes #60, bringing the mathematical description in the supplement in line with the one in the the `baselinenowcast` package.

## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
