### PR TITLE
Issue 70: Add description of KIT simple nowcast bug to supplement

### DIFF
--- a/docs/ref.bib
+++ b/docs/ref.bib
@@ -12,3 +12,31 @@
     number = {8},
 
 }
+
+@software{respinow_hub_2025,
+  title        = {{RESPINOW-Hub: Nowcasting and Short-term Forecasting Platform for Respiratory Diseases}},
+  author       = {{KIT Metrics Lab} and {Johannes Bracher} and {Melanie Schienle}},
+  year         = {2025},
+  month        = feb,
+  publisher    = {GitHub},
+  version      = {main},
+  url          = {https://github.com/KITmetricslab/RESPINOW-Hub},
+  urldate      = {2025-06-25},
+  note         = {Collaborative platform for nowcasting respiratory syncytial virus (RSV), pneumococcal, seasonal influenza, and COVID-19. Funded by the German Federal Ministry of Education and Research (BMBF).},
+  organization = {Karlsruhe Institute of Technology}
+}
+
+@software{hospitalization_nowcast_hub_2025,
+  title        = {{Hospitalization Nowcast Hub}},
+  subtitle     = {Collecting nowcasts of the 7-day hospitalization incidence in Germany},
+  author       = {{KIT Metrics Lab} and {Johannes Bracher} and {Daniel Wolffram} and {Melanie Schienle}},
+  year         = {2025},
+  month        = jan,
+  publisher    = {GitHub},
+  version      = {main},
+  url          = {https://github.com/KITmetricslab/hospitalization-nowcast-hub},
+  urldate      = {2025-06-25},
+  note         = {Collaborative project for real-time nowcasting of COVID-19 hospitalization incidences in Germany. Data sources from Robert Koch Institute (RKI).},
+  organization = {Karlsruhe Institute of Technology},
+  license      = {MIT}
+}

--- a/docs/supplement.qmd
+++ b/docs/supplement.qmd
@@ -127,9 +127,15 @@ We can sample for any number of draws, and then use the draws to compute any des
 
 \*\* To be filled in\*\*
 
+### Description of KIT simple nowcast implementation issue and revised nowcasts
+
+When verifying the KIT simple nowcast implementation, we noticed that the code used to generate the KIT simple nowcasts in real-time contained an additional indexed element in the delay PMF for all counts observed beyond the maximum delay thus far. In the generation of retrospective nowcasts, these values were being handled as having been observed as 0s, when in fact they had yet to be observed in all of the retrospective nowcasts. This resulted in a comparison of a 0 to a later observed value – which has the impact of inflating the dispersion estimates, and may explain why the KIT simple nowcast method in Wolffram et al. [@Wolffram2023] overcovers relative to the other methods. In the latest implementation in the RESPINOW Hub [@respinow_hub_2025], the authors have removed the density beyond the maximum delay column from their implementation, and thus it no longer contains this issue.
+
+In order to validate our `baselinenowcast` method against a revised version with the bug fixed, we regenerated the nowcasts using the pre-processed reporting triangle in the German Nowcast Hub repository [@hospitalization_nowcast_hub_2025] and generated retrospective nowcasts, referring to these in the main text and supplement as the KIT simple nowcast revised.
+
 ## Additional figures
 
-### German nowcast Hub validation
+### German nowcast Hub validation using revised KIT simple nowcast
 
 ![Fig.S1 Validation of baseline nowcasting model using German COVID-19 data compared to revised KIT simple nowcast. A. Weekly nowcasts from our baseline model and the KIT simple nowcast revised model against eventually observed national values, coloured by model, with data available at nowcast date (dotted lines). Nowcasts are shown daily with a 14-day horizon. B. Overall performance comparison between models, with decomposed WIS (dispersion, overprediction, underprediction) displayed as stacked bar charts for direct comparison. Stratified by national and age group nowcasts. C. Performance over time, displaying daily mean WIS scores summarised across age strata and 28 horizon days, coloured by model. D. Performance by age group, showing WIS scores across different age groups on the x axis with grouped bars for both models and stacked components displaying the decomposition of scores. E. Mean reporting delay over time, visualised as multiple coloured lines representing each age group, with the national average shown as a thicker black line. F. Empirical coverage at 50% and 90% prediction intervals for each model.](../output/figs/supp/fig_hub_validation_vs_KIT_revised.png){#figs1}
 
@@ -157,8 +163,6 @@ We can sample for any number of draws, and then use the draws to compute any des
 
 ![Fig S11. Absolute WIS over time (by week) for each model.](../output/figs/supp/wis_over_time_noro.png){#figs11}
 
-![Fig S12. Absolute WIS by day of week for each model.](../output/figs/supp/wis_by_weekday.png){#figs12}
-![Fig S13. Empirical coverage at 50% and 90% prediction intervals for each model.](../output/figs/supp/noro_coverage.png){#figs13}
-![Fig S14. Empirical coverage at 50% and 90% prediction intervals by day of week for each model.](../output/figs/supp/noro_cov_wday.png){#figs14}
+![Fig S12. Absolute WIS by day of week for each model.](../output/figs/supp/wis_by_weekday.png){#figs12} ![Fig S13. Empirical coverage at 50% and 90% prediction intervals for each model.](../output/figs/supp/noro_coverage.png){#figs13} ![Fig S14. Empirical coverage at 50% and 90% prediction intervals by day of week for each model.](../output/figs/supp/noro_cov_wday.png){#figs14}
 
 ## References

--- a/docs/supplement.qmd
+++ b/docs/supplement.qmd
@@ -163,6 +163,10 @@ In order to validate our `baselinenowcast` method against a revised version with
 
 ![Fig S11. Absolute WIS over time (by week) for each model.](../output/figs/supp/wis_over_time_noro.png){#figs11}
 
-![Fig S12. Absolute WIS by day of week for each model.](../output/figs/supp/wis_by_weekday.png){#figs12} ![Fig S13. Empirical coverage at 50% and 90% prediction intervals for each model.](../output/figs/supp/noro_coverage.png){#figs13} ![Fig S14. Empirical coverage at 50% and 90% prediction intervals by day of week for each model.](../output/figs/supp/noro_cov_wday.png){#figs14}
+![Fig S12. Absolute WIS by day of week for each model.](../output/figs/supp/wis_by_weekday.png){#figs12}
+
+![Fig S13. Empirical coverage at 50% and 90% prediction intervals for each model.](../output/figs/supp/noro_coverage.png){#figs13}
+
+![Fig S14. Empirical coverage at 50% and 90% prediction intervals by day of week for each model.](../output/figs/supp/noro_cov_wday.png){#figs14}
 
 ## References


### PR DESCRIPTION
## Description

This PR closes #70. It adds a text description of the bug in the KIT simple nowcast implementation and describes how the KIT simple nowcast revised nowcasts were generated


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added two new software references to the bibliography for RESPINOW-Hub and Hospitalization Nowcast Hub.
  - Updated the supplement to describe an implementation issue and its resolution in the KIT simple nowcast method, and clarified the validation process using a revised version.
  - Consolidated figure references at the end of the supplement for improved readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->