### PR TITLE
Issue 108: add coverage metrics on validation study to report

### DIFF
--- a/report.Rmd
+++ b/report.Rmd
@@ -196,6 +196,19 @@ rel_wis |>
   kable(caption = "Min and max relative WIS by age group")
 ```
 
+Coverage by model
+```{r}
+validation_coverage |>
+  group_by(model, interval_range) |>
+  summarise(empirical_coverage = sum(interval_coverage) / n()) |>
+  filter(interval_range %in% c(50, 95)) |>
+  pivot_wider(
+    names_from = interval_range,
+    values_from = empirical_coverage
+  ) |>
+  kable(caption = "Model validation: coverage summary")
+```
+
 # Model permutation results
 ```{r, echo = FALSE}
 scores_mp |>


### PR DESCRIPTION
## Description

This PR closes #108. Coverage metrics are now reported in the report, used to generate the quantitative results for the manuscript.


## Checklist

- [X] My PR is based on a package issue and I have explicitly linked it.
- [X] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [X] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a summary table displaying empirical coverage metrics by model and interval range (50 and 95) to the report for easier validation review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->