### PR TITLE
Issue 110: rerun analysis using the retrospectively produced nowcasts from original implementation

### DIFF
--- a/R/plotting_style.R
+++ b/R/plotting_style.R
@@ -31,7 +31,7 @@ plot_components <- function() {
   pal_mps <- brewer.pal(12, "Paired")
   # nolint start
   model_colors <- c(
-    "KIT simple nowcast" = "darkorange",
+    "KIT simple nowcast original" = "darkorange",
     "KIT simple nowcast revised" = "darkgreen",
     "baselinenowcast" = "purple4",
     "Default" = "purple4",

--- a/targets/figures_hub_validation_targets.R
+++ b/targets/figures_hub_validation_targets.R
@@ -34,32 +34,32 @@ figures_hub_validation_targets <- list(
   tar_target(
     name = validation_scoresr,
     command = validation_scores |>
-      filter(model != "KIT simple nowcast")
+      filter(model != "KIT simple nowcast original")
   ),
   tar_target(
     name = combined_nowcastsr,
     command = combined_nowcasts |>
-      filter(model != "KIT simple nowcast")
+      filter(model != "KIT simple nowcast original")
   ),
   tar_target(
     name = validation_coverager,
     command = validation_coverage |>
-      filter(model != "KIT simple nowcast")
+      filter(model != "KIT simple nowcast original")
   ),
   tar_target(
     name = scores_by_age_groupr,
     command = scores_by_age_group |>
-      filter(model != "KIT simple nowcast")
+      filter(model != "KIT simple nowcast original")
   ),
   tar_target(
     name = scores_over_time_agr,
     command = scores_over_time_ag |>
-      filter(model != "KIT simple nowcast")
+      filter(model != "KIT simple nowcast original")
   ),
   tar_target(
     name = scores_over_time_ntlr,
     command = scores_over_time_ntl |>
-      filter(model != "KIT simple nowcast")
+      filter(model != "KIT simple nowcast original")
   ),
   # Subplots for Supp Figure Hub validation vs KIT real-time ---------------------------
   tar_target(

--- a/targets/kit_nowcast_targets.R
+++ b/targets/kit_nowcast_targets.R
@@ -4,7 +4,8 @@ kit_nowcast_targets <- list(
   tar_target(
     name = kit_nowcast_url,
     command = get_kit_nowcast_url(
-      prefix = config$covid$KIT_nowcast_url_prefix,
+      # prefix = config$covid$KIT_nowcast_url_prefix,
+      prefix = "https://raw.githubusercontent.com/kaitejohnson/hospitalization-nowcast-hub/refs/heads/main/data-processed_retrospective/KIT-simple_nowcast_original",
       nowcast_date = nowcast_dates_covid
     )
   ),
@@ -26,7 +27,7 @@ kit_nowcast_targets <- list(
         predicted = value
       ) |>
       mutate(
-        model = "KIT simple nowcast"
+        model = "KIT simple nowcast original"
       )
   ),
   tar_target(


### PR DESCRIPTION

## Description

This PR closes #110. It uses the nowcasts produced in https://github.com/kaitejohnson/hospitalization-nowcast-hub/pull/4 and regenerates figures/ analysis using the original KIT simple nowcast implementation applied to the retrospective reporting triangle, consistent with both the revised implementation and the baselinenowcast implementation that we are using. 


## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->
