### PR TITLE
Hot fix: figure tweaks 

### DIFF
--- a/R/figures_hub_validation.R
+++ b/R/figures_hub_validation.R
@@ -622,7 +622,7 @@ get_plot_bar_chart_coverage <- function(
 #' @returns ggplot object
 get_plot_rel_wis_by_age_group <- function(
     scores_by_age_group,
-    KIT_comparison_model = "KIT simple nowcast revised",
+    KIT_comparison_model = "revised KIT simple nowcast",
     fig_file_name = NULL,
     fig_file_dir = file.path("output", "figs", "supp"),
     save = TRUE) {
@@ -750,7 +750,7 @@ get_plot_mean_wis_by_horizon <- function(
 get_plot_rel_wis_by_horizon <- function(
     scores,
     strata,
-    KIT_comparison_model = "KIT simple nowcast revised",
+    KIT_comparison_model = "revised KIT simple nowcast",
     fig_file_name = NULL,
     fig_file_dir = file.path("output", "figs", "supp"),
     save = TRUE) {

--- a/R/figures_hub_validation.R
+++ b/R/figures_hub_validation.R
@@ -608,7 +608,7 @@ get_plot_bar_chart_coverage <- function(
 #' @param scores_by_age_group Dataframe of the summarised scores by age group
 #'    and model
 #' @param KIT_comparison_model Character string indicating which of the KIT
-#'     models to compare to. Default is `"KIT simple nowcast revised"`.
+#'     models to compare to. Default is `"revised KIT simple nowcast"`.
 #' @param fig_file_dir Path to save figure. Default is
 #'    `file.path("output", "figs", "supp")`.
 #' @inheritParams make_fig_hub_validation

--- a/R/figures_model_permutations.R
+++ b/R/figures_model_permutations.R
@@ -51,6 +51,9 @@ get_plot_nowcasts_over_time_mp <- function(combined_nowcasts,
       bind_rows(mutate(nc_base, model_variation = {{ permutation_grouping }}))
   }
 
+  nc_perms <- nc_perms |>
+    mutate(facet_title = glue::glue("{age_group}: {model_variation}"))
+
   plot_colors <- plot_components()
   p <- ggplot(nc_perms) +
     geom_ribbon(
@@ -112,7 +115,7 @@ get_plot_nowcasts_over_time_mp <- function(combined_nowcasts,
         )
       )
     ) +
-    facet_wrap(~model_variation, nrow = 3) +
+    facet_wrap(~facet_title, nrow = 3) +
     get_plot_theme() +
     scale_x_date(
       date_breaks = "1 month",
@@ -361,7 +364,8 @@ get_plot_rel_wis_over_time_mp <- function(scores,
     guides(color = "none") +
     scale_y_continuous(trans = "log10") +
     # theme( axis.text.x = element_text(angle = 45, hjust = 1)) +
-    ylab("Relative WIS")
+    ylab("Relative WIS") +
+    theme(axis.title.y = element_text(size = 16))
 
   return(p)
 }
@@ -1165,20 +1169,23 @@ make_panel_A_mps_2_ags <- function(
 
   fig_panel_A <- (plot_nowcasts_t_mp_borrow1 + labs(tag = " A i") +
     theme(plot.tag.position = c(0, 0.7))) +
-    (rel_wis_over_time_mp_borrow1 + labs(tag = "ii")) +
+    (rel_wis_over_time_mp_borrow1 + labs(tag = "ii") +
+      theme(plot.tag.position = c(-0.01, 1.01))) +
     (plot_nowcasts_t_mp_rep_tri1 + labs(tag = "iii")) +
-    (rel_wis_over_time_mp_rep_tri1 + labs(tag = "iv")) +
+    (rel_wis_over_time_mp_rep_tri1 + labs(tag = "iv") +
+      theme(plot.tag.position = c(-0.01, 1.01))) +
     (plot_nowcasts_t_mp_volume1 + labs(tag = "v")) +
     (rel_wis_over_time_mp_volume1 + labs(tag = "vi") +
-      theme(plot.tag.position = c(-0.01, 1))) +
+      theme(plot.tag.position = c(-0.01, 1.01))) +
     (plot_nowcasts_t_mp_borrow2 + labs(tag = "vii") +
-      theme(plot.tag.position = c(0, 0.7))) +
+      theme(plot.tag.position = c(-0.01, 1.01))) +
     (rel_wis_over_time_mp_borrow2 + labs(tag = "viii")) +
     (plot_nowcasts_t_mp_rep_tri2 + labs(tag = "ix")) +
-    (rel_wis_over_time_mp_rep_tri2 + labs(tag = "x")) +
+    (rel_wis_over_time_mp_rep_tri2 + labs(tag = "x") +
+      theme(plot.tag.position = c(-0.01, 1.01))) +
     (plot_nowcasts_t_mp_volume2 + labs(tag = "xi")) +
     (rel_wis_over_time_mp_volume2 + labs(tag = "xii") +
-      theme(plot.tag.position = c(-0.01, 1))) +
+      theme(plot.tag.position = c(-0.01, 1.01))) +
     plot_layout(
       design = fig_layout,
       axes = "collect"

--- a/R/plotting_style.R
+++ b/R/plotting_style.R
@@ -31,8 +31,8 @@ plot_components <- function() {
   pal_mps <- brewer.pal(12, "Paired")
   # nolint start
   model_colors <- c(
-    "KIT simple nowcast original" = "darkorange",
-    "KIT simple nowcast revised" = "darkgreen",
+    "original KIT simple nowcast" = "darkorange",
+    "revised KIT simple nowcast" = "darkgreen",
     "baselinenowcast" = "purple4",
     "Default" = "purple4",
     "base" = "purple4",
@@ -45,6 +45,7 @@ plot_components <- function() {
     "baselinenowcast_model2" = "blue3",
     "baselinenowcast_model3" = "maroon",
     "baselinenowcast base" = "purple4",
+    "baselinenowcast base \nspecification" = "purple4",
     "baselinenowcast weekday\nfilter small training volume" = "blue3",
     "baselinenowcast weekday\nfilter large training volume" = "maroon"
   )

--- a/docs/supplement.qmd
+++ b/docs/supplement.qmd
@@ -40,7 +40,7 @@ $$X_{t,>d} = \sum_{i = d+1} ^{D} X_{t,i}$$
 representing the number of cases still missing after $d$ days of delay. In the following we use uppercase letters ($X_t$) for random variables, lower case ($x_t$) for the corresponding observations, and hats ($\hat{x}_t$) for estimated / imputed values. The matrix $\mathbf{x}$ with entries $x_{t,d}, t = 1, \dots, t^*, d = 1, \dots, D$ is referred to as the *reporting matrix*:
 
 |   | $d = 0$ | $d = 1$ | $d=2$ | $...$ | $d= D-1$ | $d= D$ |
-|-----------|-----------|-----------|-----------|-----------|-----------|-----------|
+|----|----|----|----|----|----|----|
 | $t=1$ | $x_{1,0}$ | $x_{1,1}$ | $x_{1,2}$ | $...$ | $x_{1,D-1}$ | $x_{1, D}$ |
 | $t=2$ | $x_{2,0}$ | $x_{2,1}$ | $x_{2,2}$ | $...$ | $x_{2,D-1}$ | $x_{2, D}$ |
 | $t=3$ | $x_{3,0}$ | $x_{3,1}$ | $x_{3,2}$ | $...$ | $x_{3,D-1}$ | $x_{3, D}$ |

--- a/man/get_plot_rel_wis_by_age_group.Rd
+++ b/man/get_plot_rel_wis_by_age_group.Rd
@@ -6,7 +6,7 @@
 \usage{
 get_plot_rel_wis_by_age_group(
   scores_by_age_group,
-  KIT_comparison_model = "KIT simple nowcast revised",
+  KIT_comparison_model = "revised KIT simple nowcast",
   fig_file_name = NULL,
   fig_file_dir = file.path("output", "figs", "supp"),
   save = TRUE

--- a/man/get_plot_rel_wis_by_age_group.Rd
+++ b/man/get_plot_rel_wis_by_age_group.Rd
@@ -17,7 +17,7 @@ get_plot_rel_wis_by_age_group(
 and model}
 
 \item{KIT_comparison_model}{Character string indicating which of the KIT
-models to compare to. Default is \code{"KIT simple nowcast revised"}.}
+models to compare to. Default is \code{"revised KIT simple nowcast"}.}
 
 \item{fig_file_name}{Character string indicating name of the figure to be
 saved as the file name. Default is \code{NULL}.}

--- a/man/get_plot_rel_wis_by_horizon.Rd
+++ b/man/get_plot_rel_wis_by_horizon.Rd
@@ -7,7 +7,7 @@
 get_plot_rel_wis_by_horizon(
   scores,
   strata,
-  KIT_comparison_model = "KIT simple nowcast revised",
+  KIT_comparison_model = "revised KIT simple nowcast",
   fig_file_name = NULL,
   fig_file_dir = file.path("output", "figs", "supp"),
   save = TRUE

--- a/report.Rmd
+++ b/report.Rmd
@@ -172,7 +172,7 @@ scores_sum <- validation_scores |>
   summarise_scores(by = c("model", "age_group"))
 
 comparison_score_rt <- scores_sum |>
-  filter(model == "KIT simple nowcast revised") |>
+  filter(model == "revised KIT simple nowcast") |>
   rename(KIT_rt_wis = wis) |>
   select(KIT_rt_wis, age_group)
 
@@ -182,7 +182,7 @@ rel_wis <- scores_sum |>
   mutate(
     relative_wis = wis / pmax(KIT_rt_wis, .Machine$double.eps),
     strata = "age groups",
-    relative_to = "KIT simple nowcast original"
+    relative_to = "original KIT simple nowcast"
   ) |>
   select(relative_wis, relative_to, age_group, model)
 

--- a/report.Rmd
+++ b/report.Rmd
@@ -35,12 +35,12 @@ scores_sum <- validation_scores |>
   summarise_scores(by = "model")
 
 comparison_score_rt <- scores_sum |>
-  filter(model == "KIT simple nowcast original") |>
+  filter(model == "original KIT simple nowcast") |>
   rename(KIT_rt_wis = wis) |>
   select(KIT_rt_wis)
 
 comparison_score_rev <- scores_sum |>
-  filter(model == "KIT simple nowcast revised") |>
+  filter(model == "revised KIT simple nowcast") |>
   rename(KIT_rev_wis = wis) |>
   select(KIT_rev_wis)
 
@@ -50,7 +50,7 @@ rel_wis <- scores_sum |>
   mutate(
     relative_wis = wis / pmax(KIT_rt_wis, .Machine$double.eps),
     strata = "age groups",
-    relative_to = "KIT simple nowcast original"
+    relative_to = "original KIT simple nowcast"
   ) |>
   select(relative_wis, relative_to, model)
 
@@ -60,7 +60,7 @@ rel_wis_rev <- scores_sum |>
   mutate(
     relative_wis = wis / pmax(KIT_rev_wis, .Machine$double.eps),
     strata = "age groups",
-    relative_to = "KIT simple nowcast revised"
+    relative_to = "revised KIT simple nowcast"
   ) |>
   select(relative_wis, relative_to, model)
 ```
@@ -84,12 +84,12 @@ scores_sum <- validation_scores |>
   summarise_scores(by = "model")
 
 comparison_score_rt <- scores_sum |>
-  filter(model == "KIT simple nowcast original") |>
+  filter(model == "original KIT simple nowcast") |>
   rename(KIT_rt_wis = wis) |>
   select(KIT_rt_wis)
 
 comparison_score_rev <- scores_sum |>
-  filter(model == "KIT simple nowcast revised") |>
+  filter(model == "revised KIT simple nowcast") |>
   rename(KIT_rev_wis = wis) |>
   select(KIT_rev_wis)
 
@@ -99,7 +99,7 @@ rel_wis_ntl <- scores_sum |>
   mutate(
     relative_wis = wis / pmax(KIT_rt_wis, .Machine$double.eps),
     strata = "national",
-    relative_to = "KIT simple nowcast original"
+    relative_to = "original KIT simple nowcast"
   ) |>
   select(relative_wis, relative_to, model)
 
@@ -109,7 +109,7 @@ rel_wis_rev_ntl <- scores_sum |>
   mutate(
     relative_wis = wis / pmax(KIT_rev_wis, .Machine$double.eps),
     strata = "national",
-    relative_to = "KIT simple nowcast revised"
+    relative_to = "revised KIT simple nowcast"
   ) |>
   select(relative_wis, relative_to, model)
 ```

--- a/targets/figures_hub_validation_targets.R
+++ b/targets/figures_hub_validation_targets.R
@@ -1,65 +1,65 @@
 figures_hub_validation_targets <- list(
-  # Filter the plot target inputs to exclude KIT simple nowcast revised-------
+  # Filter the plot target inputs to exclude revised KIT simple nowcast-------
   tar_target(
     name = validation_scores2,
     command = validation_scores |>
-      filter(model != "KIT simple nowcast revised")
+      filter(model != "revised KIT simple nowcast")
   ),
   tar_target(
     name = combined_nowcasts2,
     command = combined_nowcasts |>
-      filter(model != "KIT simple nowcast revised")
+      filter(model != "revised KIT simple nowcast")
   ),
   tar_target(
     name = validation_coverage2,
     command = validation_coverage |>
-      filter(model != "KIT simple nowcast revised")
+      filter(model != "revised KIT simple nowcast")
   ),
   tar_target(
     name = scores_by_age_group2,
     command = scores_by_age_group |>
-      filter(model != "KIT simple nowcast revised")
+      filter(model != "revised KIT simple nowcast")
   ),
   tar_target(
     name = scores_over_time_ag2,
     command = scores_over_time_ag |>
-      filter(model != "KIT simple nowcast revised")
+      filter(model != "revised KIT simple nowcast")
   ),
   tar_target(
     name = scores_over_time_ntl2,
     command = scores_over_time_ntl |>
-      filter(model != "KIT simple nowcast revised")
+      filter(model != "revised KIT simple nowcast")
   ),
   # Alt: filter the plot target inputs to exclude KIT simple nowcast ------
   tar_target(
     name = validation_scoresr,
     command = validation_scores |>
-      filter(model != "KIT simple nowcast original")
+      filter(model != "original KIT simple nowcast")
   ),
   tar_target(
     name = combined_nowcastsr,
     command = combined_nowcasts |>
-      filter(model != "KIT simple nowcast original")
+      filter(model != "original KIT simple nowcast")
   ),
   tar_target(
     name = validation_coverager,
     command = validation_coverage |>
-      filter(model != "KIT simple nowcast original")
+      filter(model != "original KIT simple nowcast")
   ),
   tar_target(
     name = scores_by_age_groupr,
     command = scores_by_age_group |>
-      filter(model != "KIT simple nowcast original")
+      filter(model != "original KIT simple nowcast")
   ),
   tar_target(
     name = scores_over_time_agr,
     command = scores_over_time_ag |>
-      filter(model != "KIT simple nowcast original")
+      filter(model != "original KIT simple nowcast")
   ),
   tar_target(
     name = scores_over_time_ntlr,
     command = scores_over_time_ntl |>
-      filter(model != "KIT simple nowcast original")
+      filter(model != "original KIT simple nowcast")
   ),
   # Subplots for Supp Figure Hub validation vs KIT real-time ---------------------------
   tar_target(
@@ -243,7 +243,7 @@ figures_hub_validation_targets <- list(
     command = get_plot_rel_wis_by_horizon(
       validation_scoresr,
       strata = "age groups",
-      KIT_comparison_model = "KIT simple nowcast revised",
+      KIT_comparison_model = "revised KIT simple nowcast",
       fig_file_name = "rel_wis_comp_revised_ag"
     )
   ),
@@ -252,7 +252,7 @@ figures_hub_validation_targets <- list(
     command = get_plot_rel_wis_by_horizon(
       validation_scoresr,
       strata = "national",
-      KIT_comparison_model = "KIT simple nowcast revised",
+      KIT_comparison_model = "revised KIT simple nowcast",
       fig_file_name = "rel_wis_comp_revised_ntl"
     )
   ),

--- a/targets/kit_nowcast_targets.R
+++ b/targets/kit_nowcast_targets.R
@@ -27,7 +27,7 @@ kit_nowcast_targets <- list(
         predicted = value
       ) |>
       mutate(
-        model = "KIT simple nowcast original"
+        model = "original KIT simple nowcast"
       )
   ),
   tar_target(
@@ -68,7 +68,7 @@ kit_nowcast_targets <- list(
         predicted = value
       ) |>
       mutate(
-        model = "KIT simple nowcast revised"
+        model = "revised KIT simple nowcast"
       )
   ),
   tar_target(


### PR DESCRIPTION
## Description
 Makes a few minor tweaks to the figures, changing the name of the KIT models and adding age groups to the titles of the paneled plots.

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [X] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [X] I have tested my changes locally.
- [X] I have added or updated unit tests where necessary.
- [X] I have updated the documentation if required.
- [X] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Updated model naming conventions throughout the application for improved consistency and clarity (e.g., "KIT simple nowcast revised" is now "revised KIT simple nowcast").
  * Enhanced plot facet labels to display both age group and model variation.
  * Improved y-axis title sizing and repositioned plot annotation tags for better visual presentation.
  * Adjusted Markdown table formatting in documentation for cleaner appearance.

* **Bug Fixes**
  * Corrected default model names in plotting functions and filtering criteria to match updated naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->