### PR TITLE
Hot fix: fix legend bug

### DIFF
--- a/R/figures_model_permutations.R
+++ b/R/figures_model_permutations.R
@@ -106,13 +106,7 @@ get_plot_nowcasts_over_time_mp <- function(combined_nowcasts,
       ),
       guide = guide_legend(
         nrow = 2,
-        title.position = "top",
-        override.aes = list(
-          alpha = c(
-            "95%" = 0.2,
-            "50%" = 0.4
-          )
-        )
+        title.position = "top"
       )
     ) +
     facet_wrap(~facet_title, nrow = 3) +
@@ -133,10 +127,6 @@ get_plot_nowcasts_over_time_mp <- function(combined_nowcasts,
         title.position = "top",
         nrow = 3,
         override.aes = list(
-          color = c(
-            "Final evaluation data" = "red",
-            "Data as of nowcast date" = "gray"
-          ),
           linewidth = 1
         )
       )
@@ -155,7 +145,7 @@ get_plot_nowcasts_over_time_mp <- function(combined_nowcasts,
   if (isTRUE(save)) {
     dir_create(fig_file_dir)
     ggsave(
-      plot = p,
+      plot = p + guides(fill = guide_legend("Method specification")),
       filename = file.path(
         fig_file_dir,
         glue("{fig_file_name}.png")


### PR DESCRIPTION

 
## Description

Realised in making the figure for blog that the override legend accidentally swapped the colors of the legend key for the final vs initial data


## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured saved plots include a fill legend titled “Method specification.”

* **Style**
  * Simplified legends for prediction intervals by removing enforced alpha settings.
  * Cleaned up observed-data legend entries by removing forced colors and line widths.
  * Overall, legends are clearer and more consistent between on-screen display and saved outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->