### PR TITLE
Issue 126: Move methods to supplement and rewrite methods in main text

### DIFF
--- a/docs/supplement_short.qmd
+++ b/docs/supplement_short.qmd
@@ -229,7 +229,56 @@ $$
 \mathbb{E}(N \ |\ Y = y)  = \frac{(y + 1 -p)/p^2}{1/p} = \frac{y + 1 - p}{p},
 $$ which corresponds to the corrected point estimate provided in equation @eq-correction.
 
-### Description of KIT simple nowcast implementation issue and revised nowcasts
+### `baselinenowcast` defaults
+We use the following default model choices:
+1. We estimate the delay from partial observations available in the reporting triangle.
+2. Past nowcast errors are computed by aggregating across delays to estimate uncertainty by horizon.
+3. We assume a Negative Binomial observation model on reported cases.
+
+As well as model choices, we also make data ingestion assumptions in our default approach. These are all conditioned on the maximum delay observed in the data making them more robust to different datasets. The maximum delay is set by the user when creating the reporting triangle based on when the data is expected to stabilize, with shorter maximum delays being more computationally efficient.
+
+1. Overall data use: We use three times the maximum delay number of reference times (in line with [@Wolffram2023]).
+2. Delay distribution estimation: 50% of the reference times are used for delay estimation, with a minimum requirement of at least one more than the number of reference times with partial observations.
+3. Uncertainty Estimation: 50% of the reference times are used as retrospective point nowcast times. If there is insufficient data, the method uses the oldest retrospective nowcast time with at least the same amount of historical data for delay estimation as is used for the point nowcast at the current nowcast time, and requires that there are at least two retrospective nowcasts containing sufficient data.
+
+### Available options for model specification
+As our method is modular with each step being independent, there are a large number of potential variations, designed with common scenarios in infectious disease surveillance in mind. We have implemented the following:
+
+Input data options:
+
+- Use of a complete reporting matrix or a reporting triangle.
+
+- Changing the total number of reference time points used to estimate the delay distribution and uncertainty parameters, balancing precision (from more data) against capturing recent variability (from more current data).
+
+- Reference and report dates of different temporal granularities, e.g. daily reporting of weekly reference dates, weekly reporting of daily reference dates, and weekly reference and report dates.
+
+Delay estimation approaches:
+
+- Estimate delays from the same data set / stratum being nowcasted or “borrow” estimates from another reporting triangle. This may be useful for sparse data sets, such as in small subpopulations or locations or for rare pathogens and emerging outbreaks.
+
+- Changing the proportion of data used to estimate the delay with the same tradeoffs as for changing the overall amount of data input.
+
+- Adjusting the maximum delay, but this should be based on empirically observed delay rather than being viewed as a modelling option.
+
+Uncertainty quantification variations:
+
+- Observation models can be fit using different datasets than those used for delay estimation or for the nowcast.
+
+- Changing the proportion of data used to estimate the observation model with the same tradeoffs as in the delay estimation case.
+
+- The parametric form of the observation model can be changed.
+
+- The observation model can be fit jointly for any grouping of observations. The target choice for the final nowcast can be specified such that the uncertainty estimation occurs on this target (i.e. 7-day rolling sum).
+
+## Evaluation analyses
+
+### German COVID-19 Nowcast Hub validation
+
+### Performance of different baselinenowcast method specifications applied to German COVID-19 data
+
+### Case study: UKHSA norovirus surveillance
+
+## Description of KIT simple nowcast implementation issue and revised nowcasts
 
 When verifying the KIT simple nowcast implementation, we noticed that the code used to generate the KIT simple nowcasts in real-time contained an additional indexed element in the delay PMF for all counts observed beyond the maximum delay thus far. In the generation of retrospective nowcasts, these values were being handled as having been observed as 0s, when in fact they had yet to be observed in all of the retrospective nowcasts. This resulted in a comparison of a 0 to a value that in some cases is eventually observed, rather than beign excluded as they should have been. This has the impact of inflating the dispersion estimates, and may explain why the KIT simple nowcast method in Wolffram et al. [@Wolffram2023] overcovers relative to the other methods. In the latest implementation in the RESPINOW Hub [@respinow_hub_2025], the authors have removed the density beyond the maximum delay column from their implementation, and thus it no longer contains this issue.
 


### PR DESCRIPTION
## Description

This PR closes #126. It moves over parts of the main text to the supplement. 

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Documentation
  - Added comprehensive defaults section clarifying assumptions for delays, uncertainty, and observation model.
  - Defined data requirements and parameterization rules based on maximum observed delay.
  - Documented uncertainty estimation workflow with fallbacks for sparse data.
  - Introduced “Available options for model specification” covering input formats, delay estimation, uncertainty methods, grouping, and targets.
  - Expanded Evaluation with German COVID-19 validation, variant comparisons, and a UK norovirus case study.
  - Refined headings and structure for the KIT simple nowcast issue while retaining content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->