### PR TITLE
add dual license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,2 +1,10 @@
-YEAR: 2025
-COPYRIGHT HOLDER: baselinenowcastpaper authors
+Dual License
+
+This repository uses two licenses:
+
+1. Software code (R files, scripts, etc.): MIT License
+   See LICENSE-MIT.md for full text
+
+2. Documentation, figures, data, and other creative content:
+   Creative Commons Attribution 4.0 International (CC-BY 4.0)
+   See LICENSE-CC-BY.md for full text

--- a/LICENSE-CC-BY.md
+++ b/LICENSE-CC-BY.md
@@ -1,0 +1,13 @@
+# Creative Commons Attribution 4.0 International
+
+This license applies to all documentation, figures, data, and other creative content in this repository.
+
+The full license text is available at:
+https://creativecommons.org/licenses/by/4.0/legalcode
+
+You are free to:
+- Share — copy and redistribute the material in any medium or format
+- Adapt — remix, transform, and build upon the material for any purpose, even commercially
+
+Under the following terms:
+- Attribution — You must give appropriate credit, provide a link to the license, and indicate if changes were made.

--- a/LICENSE-MIT.md
+++ b/LICENSE-MIT.md
@@ -1,4 +1,6 @@
-# MIT License
+# MIT License (applies to software code)
+
+See LICENSE-CC-BY.md for the license covering documentation, figures, and data.
 
 Copyright (c) 2025 baselinenowcastpaper authors
 

--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ Results can be approximately reproduced using entirely the synthetic data provid
 
 The original and revised implementations of the KIT simple nowcast quantiles on the latest German COVID-19 hospitalization data are available at [`data-processed_retrospective`](https://github.com/kaitejohnson/hospitalization-nowcast-hub/data-processed_retrospective).
 The nowcasted quantiles for norovirus for the GAM, epinowcast, naive baseline, and baselinenowcast specifications are available at [`data/original`](https://github.com/jonathonmellor/norovirus-nowcast-baselinenowcast/outputs/data/original), with the quantiles fit to the synthetic data available at [`data/synthetic`](https://github.com/jonathonmellor/norovirus-nowcast-baselinenowcast/outputs/data/synthetic)
+
+## License
+
+This repository is dual-licensed:
+- **Code**: MIT License (see [LICENSE-MIT.md](LICENSE-MIT.md))
+- **Documentation, figures, and data**: CC-BY 4.0 (see [LICENSE-CC-BY.md](LICENSE-CC-BY.md))


### PR DESCRIPTION
## Description

This PR closes #128. It adds a dual license-- MIT for software and CC-BY for output

## Checklist

- [ ] My PR is based on a package issue and I have explicitly linked it.
- [ ] I have included the target issue or issues in the PR title in the for Issue(s) *issue-numbers*: PR title
- [ ] I have read the [contribution guidelines](https://github.com/epinowcast/.github/blob/main/CONTRIBUTING.md).
- [ ] I have tested my changes locally.
- [ ] I have added or updated unit tests where necessary.
- [ ] I have updated the documentation if required.
- [ ] My code follows the established coding standards.
- [ ] I have added a news item linked to this PR.
- [ ] I have reviewed CI checks for this PR and addressed them as far as I am able.

<!-- Thanks again for this PR - @epinowcast dev team -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Introduced a dual-licensing model: MIT License now covers software code, while Creative Commons Attribution 4.0 covers documentation, figures, data, and other content.
  * Added CC-BY 4.0 license file and updated MIT license reference to reflect the new dual-license structure.
  * Updated project documentation to detail the licensing arrangement for all project components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->